### PR TITLE
disabled vault-secrets-operator

### DIFF
--- a/science-platform/values-usdfdev.yaml
+++ b/science-platform/values-usdfdev.yaml
@@ -50,4 +50,4 @@ squash_api:
 tap:
   enabled: true
 vault_secrets_operator:
-  enabled: true
+  enabled: false


### PR DESCRIPTION
Github integration test

Disabled vault-secrets-operator in science-platform Helm chart